### PR TITLE
add missing package declaration to Pod::Confluence::TestUtil

### DIFF
--- a/t/Pod_Confluence.t
+++ b/t/Pod_Confluence.t
@@ -6,7 +6,7 @@ use lib 't/lib';
 use File::Basename;
 use File::Spec;
 use Pod::Confluence::TestUtil qw(
-    write_pod
+    pod_string
 );
 use Test::More tests => 18;
 

--- a/t/lib/Pod/Confluence/TestUtil.pm
+++ b/t/lib/Pod/Confluence/TestUtil.pm
@@ -1,3 +1,4 @@
+package Pod::Confluence::TestUtil;
 use strict;
 use warnings;
 
@@ -8,6 +9,7 @@ our @EXPORT_OK = qw(
     slurp
     spurt
     write_pod
+    pod_string
 );
 
 sub slurp {


### PR DESCRIPTION
The test module Pod::Confluence::TestUtil did not have a package statement, so it didn't work as a proper exporter and instead just dumped its subs in whatever namespace was active when first using the module. Convert it to a real package and fix the imports.

Without the package statement, the module was not set up as an exporter properly, so it had no import method. The arguments to the use statement were being ignored by perl. Future versions of perl are intending to make passing arguments to an undefined import method an error.